### PR TITLE
Fix alt tags for banners and products

### DIFF
--- a/resources/views/livewire/products/partials/grid-product.blade.php
+++ b/resources/views/livewire/products/partials/grid-product.blade.php
@@ -22,7 +22,7 @@
                         <div class="col-sm-6 col-md-4 col-lg-3 p-b-35 isotope-item {{ $categoryName }}">
                             <!-- Image du produit -->
                             <div class="block2-pic hov-img0 label-new" data-label="new">
-                                <img src="{{ $product->getFirstImageUrl() }}" alt="Image du produit"
+                                <img src="{{ $product->getFirstImageUrl() }}" alt="{{ $product['title'] }}"
                                     class="product-image">
                             </div>
                             <!-- Informations du produit -->

--- a/resources/views/livewire/products/partials/sec-banner.blade.php
+++ b/resources/views/livewire/products/partials/sec-banner.blade.php
@@ -5,7 +5,7 @@
             <div class="size-202 m-lr-auto respon4">
                 <!-- Block1 -->
                 <div class="block1 wrap-pic-w">
-                    <img src="{{ Storage::url($banner->photo) ?? 'default_image.jpg' }}" alt="IMG-BANNER">
+                    <img src="{{ Storage::url($banner->photo) ?? 'default_image.jpg' }}" alt="{{ $banner->name }}">
 
                     <a href="{{ route('home.shop', ['id' => $banner->id, 'slug' => $banner->slug]) }}"
                         class="block1-txt ab-t-l s-full flex-col-l-sb p-lr-38 p-tb-34 trans-03 respon3">


### PR DESCRIPTION
## Summary
- set banner alt to the banner name
- use product title for product image alt attribute

## Testing
- `php artisan test` *(fails: php not installed)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849c7247700832099b0d46f0cac6542