### PR TITLE
Externalize slide product assets

### DIFF
--- a/resources/css/slide-product.css
+++ b/resources/css/slide-product.css
@@ -1,0 +1,107 @@
+/* Pagination horizontale centrée proprement */
+.
+
+/* Conteneur du slider */
+.wrap-slick2 {
+    position: relative;
+    overflow: hidden;
+    padding: 0 50px;
+}
+
+/* Images totalement responsive */
+.slick2 .block2-pic img {
+    width: 100%;
+    height: auto;
+    border-radius: 10px;
+}
+
+/* Boutons Précédent et Suivant personnalisés */
+.slick2 .slick-prev,
+.slick2 .slick-next {
+    position: absolute;
+    top: 45%;
+    /* Légèrement au-dessus du centre pour mieux équilibrer */
+    transform: translateY(-50%);
+    width: 38px;
+    height: 38px;
+    background-color: rgba(255, 255, 255, 0.95);
+    border-radius: 50%;
+    border: none;
+    cursor: pointer;
+    z-index: 100;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
+}
+
+.slick2 .slick-prev {
+    left: -20px;
+}
+
+.slick2 .slick-next {
+    right: -20px;
+}
+
+/* Icônes flèches Font Awesome */
+.slick2 .slick-prev::before,
+.slick2 .slick-next::before {
+    font-family: 'Font Awesome 6 Free';
+    font-weight: 900;
+    font-size: 16px;
+    color: #555;
+}
+
+.slick2 .slick-prev::before {
+    content: "\f053";
+}
+
+.slick2 .slick-next::before {
+    content: "\f054";
+}
+
+/* Points de pagination Slick personnalisés */
+.slick2 .slick-dots {
+    position: absolute;
+    bottom: -40px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex !important;
+    gap: 10px;
+}
+
+.slick2 .slick-dots li button {
+    font-size: 0;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background-color: #ccc;
+    border: none;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.slick2 .slick-dots li.slick-active button {
+    background-color: #333;
+    width: 14px;
+    height: 14px;
+}
+
+/* Responsive (Mobile & Tablette) */
+@media(max-width: 768px) {
+
+    .slick2 .slick-prev,
+    .slick2 .slick-next {
+        width: 30px;
+        height: 30px;
+        top: 50%;
+        left: -15px;
+        right: -15px;
+    }
+
+    .slick2 .slick-prev::before,
+    .slick2 .slick-next::before {
+        font-size: 14px;
+    }
+
+    .slick2 .slick-dots {
+        bottom: -30px;
+    }
+}

--- a/resources/js/slide-product.js
+++ b/resources/js/slide-product.js
@@ -1,0 +1,41 @@
+function initSlickSlider() {
+    const slider = $('.slick2');
+
+    if (slider.hasClass('slick-initialized')) {
+        slider.slick('unslick');
+    }
+
+    slider.slick({
+        slidesToShow: 4,
+        slidesToScroll: 1,
+        infinite: true,
+        dots: false,
+        autoplay: true,
+        autoplaySpeed: 2500,
+        prevArrow: '<button type="button" class="slick-prev"></button>',
+        nextArrow: '<button type="button" class="slick-next"></button>',
+        responsive: [
+            {
+                breakpoint: 1024,
+                settings: {
+                    slidesToShow: 3
+                }
+            },
+            {
+                breakpoint: 768,
+                settings: {
+                    slidesToShow: 2
+                }
+            },
+            {
+                breakpoint: 576,
+                settings: {
+                    slidesToShow: 1
+                }
+            }
+        ]
+    });
+}
+
+document.addEventListener('livewire:update', initSlickSlider);
+document.addEventListener('DOMContentLoaded', initSlickSlider);

--- a/resources/views/livewire/products/partials/slide-product.blade.php
+++ b/resources/views/livewire/products/partials/slide-product.blade.php
@@ -1,113 +1,7 @@
 <div>
-    <style type="text/css">
-        /* Pagination horizontale centrée proprement */
-        .
-
-        /* Conteneur du slider */
-        .wrap-slick2 {
-            position: relative;
-            overflow: hidden;
-            padding: 0 50px;
-        }
-
-        /* Images totalement responsive */
-        .slick2 .block2-pic img {
-            width: 100%;
-            height: auto;
-            border-radius: 10px;
-        }
-
-        /* Boutons Précédent et Suivant personnalisés */
-        .slick2 .slick-prev,
-        .slick2 .slick-next {
-            position: absolute;
-            top: 45%;
-            /* Légèrement au-dessus du centre pour mieux équilibrer */
-            transform: translateY(-50%);
-            width: 38px;
-            height: 38px;
-            background-color: rgba(255, 255, 255, 0.95);
-            border-radius: 50%;
-            border: none;
-            cursor: pointer;
-            z-index: 100;
-            box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
-        }
-
-        .slick2 .slick-prev {
-            left: -20px;
-        }
-
-        .slick2 .slick-next {
-            right: -20px;
-        }
-
-        /* Icônes flèches Font Awesome */
-        .slick2 .slick-prev::before,
-        .slick2 .slick-next::before {
-            font-family: 'Font Awesome 6 Free';
-            font-weight: 900;
-            font-size: 16px;
-            color: #555;
-        }
-
-        .slick2 .slick-prev::before {
-            content: "\f053";
-        }
-
-        .slick2 .slick-next::before {
-            content: "\f054";
-        }
-
-        /* Points de pagination Slick personnalisés */
-        .slick2 .slick-dots {
-            position: absolute;
-            bottom: -40px;
-            left: 50%;
-            transform: translateX(-50%);
-            display: flex !important;
-            gap: 10px;
-        }
-
-        .slick2 .slick-dots li button {
-            font-size: 0;
-            width: 10px;
-            height: 10px;
-            border-radius: 50%;
-            background-color: #ccc;
-            border: none;
-            cursor: pointer;
-            transition: all 0.3s ease;
-        }
-
-        .slick2 .slick-dots li.slick-active button {
-            background-color: #333;
-            width: 14px;
-            height: 14px;
-        }
-
-        /* Responsive (Mobile & Tablette) */
-        @media(max-width: 768px) {
-
-            .slick2 .slick-prev,
-            .slick2 .slick-next {
-                width: 30px;
-                height: 30px;
-                top: 50%;
-                left: -15px;
-                right: -15px;
-            }
-
-            .slick2 .slick-prev::before,
-            .slick2 .slick-next::before {
-                font-size: 14px;
-            }
-
-            .slick2 .slick-dots {
-                bottom: -30px;
-            }
-        }
-    </style>
+    @push('styles')
+        <link rel="stylesheet" href="{{ asset('css/slide-product.css') }}">
+    @endpush
     <section class="sec-product bg0 p-t-100 p-b-50">
         <h3 class="ltext-105 cl5 txt-center respon1">
             Nouvelle collection
@@ -167,48 +61,9 @@
                 </div>
 
 
-                <script>
-                    function initSlickSlider() {
-                        const slider = $('.slick2');
-
-                        if (slider.hasClass('slick-initialized')) {
-                            slider.slick('unslick');
-                        }
-
-                        slider.slick({
-                            slidesToShow: 4,
-                            slidesToScroll: 1,
-                            infinite: true,
-                            dots: false,
-                            autoplay: true,
-                            autoplaySpeed: 2500,
-                            prevArrow: '<button type="button" class="slick-prev"></button>',
-                            nextArrow: '<button type="button" class="slick-next"></button>',
-                            responsive: [{
-                                    breakpoint: 1024,
-                                    settings: {
-                                        slidesToShow: 3
-                                    }
-                                },
-                                {
-                                    breakpoint: 768,
-                                    settings: {
-                                        slidesToShow: 2
-                                    }
-                                },
-                                {
-                                    breakpoint: 576,
-                                    settings: {
-                                        slidesToShow: 1
-                                    }
-                                }
-                            ]
-                        });
-                    }
-
-                    document.addEventListener('livewire:update', initSlickSlider);
-                    document.addEventListener('DOMContentLoaded', initSlickSlider);
-                </script>
+                @push('scripts')
+                    <script src="{{ asset('js/slide-product.js') }}"></script>
+                @endpush
 
 
     </section>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -39,6 +39,10 @@ mix
         'resources/js/main.js',
     ], 'public/js/app.js')
 
+    // Fichiers du slider produit
+    .postCss('resources/css/slide-product.css', 'public/css/slide-product.css')
+    .js('resources/js/slide-product.js', 'public/js/slide-product.js')
+
     // Ajout de version pour éviter les problèmes de cache
     .version();
 d


### PR DESCRIPTION
## Summary
- externalize slide-product CSS to a dedicated file
- move JS slider initialization to its own file
- reference these files from the blade partial
- configure Mix to compile the new assets

## Testing
- `npm run build` *(fails: vite not found)*
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c72321888320ac7370d8cdb9fdaa