### PR TITLE
Improve validation in payment flows

### DIFF
--- a/app/Http/Controllers/CheckoutOrder.php
+++ b/app/Http/Controllers/CheckoutOrder.php
@@ -20,8 +20,9 @@ class CheckoutOrder extends Controller
     {
         Log::debug('handlePayment: start');
 
-        $validated = $request->all(); // Validation désactivée temporairement
-        Log::debug('handlePayment: request data without validation', $validated);
+        // Validate all incoming data to prevent tampering
+        $validated = $this->validateRequest($request);
+        Log::debug('handlePayment: request data validated', $validated);
 
         $product = Product::findOrFail($validated['product_id']);
         Log::debug('handlePayment: product found', ['product_id' => $product->id, 'title' => $product->title]);

--- a/app/Http/Controllers/Payement.php
+++ b/app/Http/Controllers/Payement.php
@@ -18,15 +18,17 @@ class Payement extends Controller
 {
     public function handlePayment(Request $request)
     {
-        $firstName = $request->input('first_name');
-        $lastName = $request->input('last_name');
+        $validated = $this->validateRequest($request);
+
+        $firstName = $validated['first_name'];
+        $lastName = $validated['last_name'];
         $fullName = $firstName . ' ' . $lastName;
         $email = Auth::check() ? Auth::user()->email : null;
-        $address = $request->input('address');
-        $country = $request->input('country');
-        $company = $request->input('company');
+        $address = $validated['address'];
+        $country = $validated['country'];
+        $company = $validated['company'] ?? null;
 
-        $cart = json_decode($request->input('cart_json'), true);
+        $cart = json_decode($validated['cart_json'], true);
 
         if (!is_array($cart) || empty($cart)) {
             return redirect()->back()->with('error', 'Le panier est vide.');
@@ -83,5 +85,20 @@ class Payement extends Controller
 
         $paymentUrl = $maxicash->queryStringURLPayment($paymentEntry);
         return redirect()->to($paymentUrl);
+    }
+
+    /**
+     * Validate the incoming payment request data.
+     */
+    private function validateRequest(Request $request): array
+    {
+        return $request->validate([
+            'first_name' => 'required|string|max:255',
+            'last_name'  => 'required|string|max:255',
+            'address'    => 'required|string',
+            'country'    => 'required|string',
+            'company'    => 'nullable|string|max:255',
+            'cart_json'  => 'required|string',
+        ]);
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -18,7 +18,8 @@ class UserSeeder extends Seeder
                 'name' => 'Admin User',
                 'email' => 'admin@example.com',
                 'email_verified_at' => now(),
-                'password' => Hash::make('password'),
+                // Use a stronger default password for seeded admin account
+                'password' => Hash::make('AdminPassword@123'),
                 'isActive' => true,
                 'role' => 9, // 1 pour administrateur
                 'remember_token' => null,
@@ -29,7 +30,8 @@ class UserSeeder extends Seeder
                 'name' => 'Regular User',
                 'email' => 'user@example.com',
                 'email_verified_at' => now(),
-                'password' => Hash::make('password123'),
+                // Use a stronger default password for seeded user account
+                'password' => Hash::make('UserPassword@123'),
                 'isActive' => true,
                 'role' => 0, // 0 pour utilisateur normal
                 'remember_token' => null,


### PR DESCRIPTION
## Summary
- validate CheckoutOrder payment request
- validate Payement controller request and add validator method
- use stronger default passwords in UserSeeder

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684fb3914774832099bcc35a19c34a9c