### PR TITLE
Add orders table and seeder

### DIFF
--- a/database/migrations/2025_06_11_120000_create_orders_table.php
+++ b/database/migrations/2025_06_11_120000_create_orders_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('orders', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->decimal('total', 10, 2);
+            $table->enum('status', ['pending', 'processing', 'shipped', 'completed', 'cancelled'])->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('orders');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -23,6 +23,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             CategoriesTableSeeder::class,
             ArticlesTableSeeder::class,
+            OrdersTableSeeder::class,
         ]);
     }
 }

--- a/database/seeders/OrdersTableSeeder.php
+++ b/database/seeders/OrdersTableSeeder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+class OrdersTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('orders')->insert([
+            [
+                'user_id' => 1,
+                'total' => 99.99,
+                'status' => 'pending',
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'user_id' => 1,
+                'total' => 149.50,
+                'status' => 'completed',
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'user_id' => 1,
+                'total' => 200.00,
+                'status' => 'cancelled',
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add migration for `orders` table with status enum
- seed example orders with various statuses
- register `OrdersTableSeeder` in `DatabaseSeeder`

## Testing
- `npm test` *(fails: Missing script)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9b0da2148320b8cb78ab1ffbb4b6